### PR TITLE
Handle empty strings, and remove unused import

### DIFF
--- a/cutlet/cutlet.py
+++ b/cutlet/cutlet.py
@@ -69,6 +69,8 @@ class Cutlet:
         capitalized. This is typically the desired behavior if the input is a
         complete sentence.
         """
+        if not text:
+            return ''
 
         words = self.tagger.parseToNodeList(text)
 

--- a/cutlet/test/test_basic.py
+++ b/cutlet/test/test_basic.py
@@ -102,3 +102,11 @@ def test_romaji_slugs(ja, roma):
     cut = Cutlet()
     cut.use_foreign_spelling = False
     assert cut.romaji(ja) == roma
+
+@pytest.mark.parametrize('ja, roma', [
+    (None, ''),
+    ('', '')
+])
+def test_empty_string(ja, roma):
+    cut = Cutlet()
+    assert cut.romaji(ja) == roma

--- a/cutlet/test/test_basic.py
+++ b/cutlet/test/test_basic.py
@@ -1,6 +1,5 @@
 import pytest
 from cutlet import Cutlet
-import fugashi
 
 
 # Note that if there are multiple words, only the first is used


### PR DESCRIPTION
Hi,

Thanks for sharing this library. Testing it, pressed enter before pasting the text, and got the following traceback.

```bash
(venv) kinow@ranma:~/Development/python/workspace/cutlet$ cutlet

Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cutlet/venv/bin/cutlet", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/kinow/Development/python/workspace/cutlet/bin/cutlet", line 13, in <module>
    print(katsu.romaji(line.strip()))
  File "/home/kinow/Development/python/workspace/cutlet/cutlet/cutlet.py", line 119, in romaji
    out = out[0].capitalize() + out[1:]
IndexError: string index out of range
```