### PR TITLE
Slight optimization of fallback for is_ascii

### DIFF
--- a/cutlet/cutlet.py
+++ b/cutlet/cutlet.py
@@ -2,6 +2,7 @@ import fugashi
 import jaconv
 import re
 import pathlib
+import sys
 
 from .mapping import *
 
@@ -14,12 +15,15 @@ SYSTEMS = {
         'nihon': NIHONSHIKI,
 }
 
-def isascii(word):
-    try:
-       word.encode('ascii');
-       return True
-    except UnicodeEncodeError:
-       return False
+if sys.version_info >= (3, 7):
+    def is_ascii(s):
+        return s.isascii()
+else:
+    def is_ascii(s):
+        for c in s: 
+            if c > '\x7f': 
+                return False 
+        return True 
 
 def has_foreign_lemma(word):
     """Check if a word has a foreign lemma.


### PR DESCRIPTION
* When native `.isascii` is present (i.e. we are on Python 3.7+) use that directly.

* I performed some rough benchmarks for the fallback between these two different approaches:

```
    def isascii_loop(s):
        for c in s: 
            if c > '\x7f': 
                return False 
        return True 
```

```
def isascii_encode(word):
    try:
       word.encode('ascii');
       return True
    except UnicodeEncodeError:
       return False
```

On ascii-inputs, the results were:

```
In [19]: ascii_input = "abcdef"                                                                    
In [20]: %timeit isascii_loop(ascii_input)                                                          
403 ns ± 8.66 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [21]: %timeit isascii_encode(ascii_input)                                                        
280 ns ± 3.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

On non-ascii input

```
In [28]: kana_input = "あいうえおん"                                                                
In [29]: %timeit isascii_loop(kana_input)                                                           
220 ns ± 2.73 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [30]: %timeit isascii_encode(kana_input)                                                         
909 ns ± 7.35 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

Given that the majority of the time the input to this function will *not* be ascii, it makes more sense to use the loop-based version. (*)


(*) Since tokenization happened prior to this it seems unlikely that the input will consist of a mix of kana & non-ascii characters, so in the most-frequent case we can decide just based on the first-letter, which probably accounts for the above benchmarks.