### PR TITLE
Python 3.5 compatibility: convert path object to str before open()

### DIFF
--- a/cutlet/cutlet.py
+++ b/cutlet/cutlet.py
@@ -57,7 +57,7 @@ def has_foreign_lemma(word):
 def load_exceptions():
     cdir = pathlib.Path(__file__).parent.absolute()
     exceptions = {}
-    with open(cdir / 'exceptions.tsv', encoding='utf-8') as exceptions_file:
+    with open(str(cdir / 'exceptions.tsv'), encoding='utf-8') as exceptions_file:
         for line in exceptions_file:
             line = line.strip()
             # allow comments and blanks


### PR DESCRIPTION
Only python 3.6+ supports passing os.PathLike object to open().
Converting to string before passing in works on both, and should not affect anything else.