### PR TITLE
chore(python): remove support for older Python versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ setup(name='cutlet',
       classifiers=[
           "License :: OSI Approved :: MIT License",
           "Natural Language :: Japanese",
+          "Programming Language :: Python :: 3.8"
+          "Programming Language :: Python :: 3.9"
+          "Programming Language :: Python :: 3.10"
+          "Programming Language :: Python :: 3.11"
           ],
-      python_requires='>=3.5',
+      python_requires='>=3.8',
       package_data={'cutlet':['exceptions.tsv']},
       entry_points={
           "console_scripts": [


### PR DESCRIPTION
## Description

This PR removes support for Python 3.5-3.7 [that reached EOL](https://endoflife.date/python).
As this could be a breaking change, it would be nice to highlight this change in next release.